### PR TITLE
Added = as a character to remove when generating the dot cluster name

### DIFF
--- a/code2flowlib/engine.py
+++ b/code2flowlib/engine.py
@@ -287,7 +287,7 @@ class Group(object):
 			else:
 				raise Exception()
 		except:
-			return 'cluster'+re.sub(r"[/\.\-\(\)\s]",'',self.name)+str(self.uid)
+			return 'cluster'+re.sub(r"[/\.\-\(\)=\s]",'',self.name)+str(self.uid)
 
 	def _allNodes(self):
 		'''


### PR DESCRIPTION
This is literally a one character change, but dot doesn't like having  an '=' character in cluster names, so I added it to the regex removal.  
