### PR TITLE
djoin does not fail when including None

### DIFF
--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -48,7 +48,7 @@ def djoin(*tup):
     """
     if len(tup) == 1 and isinstance(tup[0], list):
         return '.'.join(tup[0])
-    return '.'.join(tup)
+    return '.'.join(filter(None, tup))
 
 
 def flatten(list_of_lists):


### PR DESCRIPTION
When including some modules from \_\_init\_\_.py, djoin fails:

```python
/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.6) or chardet (3.0.4) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
Traceback (most recent call last):
  File "/usr/local/bin/code2flow", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/dist-packages/code2flow/engine.py", line 630, in main
    code2flow(
  File "/usr/local/lib/python3.8/dist-packages/code2flow/engine.py", line 536, in code2flow
    file_groups, all_nodes, edges = map_it(sources, language, no_trimming,
  File "/usr/local/lib/python3.8/dist-packages/code2flow/engine.py", line 324, in map_it
    file_group = make_file_group(file_ast_tree, source, extension)
  File "/usr/local/lib/python3.8/dist-packages/code2flow/engine.py", line 208, in make_file_group
    file_group.add_node(language.make_root_node(body_trees, parent=file_group), is_root=True)
  File "/usr/local/lib/python3.8/dist-packages/code2flow/python.py", line 229, in make_root_node
    variables = make_local_variables(lines, parent)
  File "/usr/local/lib/python3.8/dist-packages/code2flow/python.py", line 122, in make_local_variables
    variables += process_import(element)
  File "/usr/local/lib/python3.8/dist-packages/code2flow/python.py", line 99, in process_import
    rhs = djoin(element.module, rhs)
  File "/usr/local/lib/python3.8/dist-packages/code2flow/model.py", line 54, in djoin
    return '.'.join(tup)
TypeError: sequence item 0: expected str instance, NoneType found
```

tup looks like this:
```python
('inputs', 'X')
(None, 'X')
```

This filters out the None.