### PR TITLE
docs: Fix a few typos

### DIFF
--- a/code2flow/javascript.py
+++ b/code2flow/javascript.py
@@ -246,7 +246,7 @@ def get_acorn_version():
 class Javascript(BaseLanguage):
     @staticmethod
     def assert_dependencies():
-        """Assert that acorn is installed and the corrent version"""
+        """Assert that acorn is installed and the correct version"""
         assert is_installed('acorn'), "Acorn is required to parse javascript files " \
                                       "but was not found on the path. Install it " \
                                       "from npm and try again."
@@ -290,7 +290,7 @@ class Javascript(BaseLanguage):
         """
         Given an AST, recursively separate that AST into lists of ASTs for the
         subgroups, nodes, and body. This is an intermediate step to allow for
-        clearner processing downstream
+        cleaner processing downstream
 
         :param tree ast:
         :returns: tuple of group, node, and body trees. These are processed

--- a/code2flow/php.py
+++ b/code2flow/php.py
@@ -268,7 +268,7 @@ class PHP(BaseLanguage):
         """
         Given a tree element, recursively separate that AST into lists of ASTs for the
         subgroups, nodes, and body. This is an intermediate step to allow for
-        clearner processing downstream
+        cleaner processing downstream
 
         :param tree ast:
         :returns: tuple of group, node, and body trees. These are processed

--- a/code2flow/python.py
+++ b/code2flow/python.py
@@ -166,7 +166,7 @@ class Python(BaseLanguage):
         """
         Given an AST, recursively separate that AST into lists of ASTs for the
         subgroups, nodes, and body. This is an intermediate step to allow for
-        clearner processing downstream
+        cleaner processing downstream
 
         :param tree ast:
         :returns: tuple of group, node, and body trees. These are processed

--- a/code2flow/ruby.py
+++ b/code2flow/ruby.py
@@ -231,7 +231,7 @@ class Ruby(BaseLanguage):
         """
         Given a tree element, recursively separate that AST into lists of ASTs for the
         subgroups, nodes, and body. This is an intermediate step to allow for
-        clearner processing downstream
+        cleaner processing downstream
 
         :param tree ast:
         :returns: tuple of group, node, and body trees. These are processed

--- a/tests/test_code/py/pytz/tzinfo.py
+++ b/tests/test_code/py/pytz/tzinfo.py
@@ -261,7 +261,7 @@ class DstTzInfo(BaseTzInfo):
         This method should be used to construct localtimes, rather
         than passing a tzinfo argument to a datetime constructor.
 
-        is_dst is used to determine the correct timezone in the ambigous
+        is_dst is used to determine the correct timezone in the ambiguous
         period at the end of daylight saving time.
 
         >>> from pytz import timezone


### PR DESCRIPTION
There are small typos in:
- code2flow/javascript.py
- code2flow/php.py
- code2flow/python.py
- code2flow/ruby.py
- tests/test_code/py/pytz/tzinfo.py

Fixes:
- Should read `cleaner` rather than `clearner`.
- Should read `correct` rather than `corrent`.
- Should read `ambiguous` rather than `ambigous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md