### PR TITLE
Add args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 composer.json
 composer.lock
 vendor
+test.py

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-![code2flow logo](https://raw.githubusercontent.com/scottrogowski/code2flow/master/assets/code2flowlogo.png)
+# PASTA - Python Abstract Syntax Trees Assistant
 
-![Version 2.5.0](https://img.shields.io/badge/version-2.5.0-brightgreen) ![Build passing](https://img.shields.io/badge/build-passing-brightgreen) ![Coverage 100%](https://img.shields.io/badge/coverage-100%25-brightgreen) ![License MIT](https://img.shields.io/badge/license-MIT-green])
+This Project is a fork of [code2flow](https://github.com/scottrogowski/code2flow).
 
-Code2flow generates [call graphs](https://en.wikipedia.org/wiki/Call_graph) for dynamic programming language. Code2flow supports Python, JavaScript, Ruby, and PHP.
+## The purpose of PASTA
+
+code2flow primarily focused on building [call graphs](https://en.wikipedia.org/wiki/Call_graph), while the focus of this project is to build out a detailed [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) diagram. Because of this change in purpose, it seemed right to fork rather than submit major changes to the original project.
+
+Furthermore, the main codebase I currently use is Python. So the focus of this fork will be detailing Python codebases into ASTs, hence (PYTHON abstract syntax trees assistant).
+
+#### Note
+
+Although this project is focused on Python codebases, other code2flow programming languages (JS, Ruby and PHP) should be backwards compatiable (but will only detail a simple call graph). Feel free to fork or submit a PR to add further functionality to JS, Ruby and PHP.
+
+---
 
 The basic algorithm is simple:
 
@@ -11,12 +21,15 @@ The basic algorithm is simple:
 1. Determine where those functions are called.
 1. Connect the dots. 
 
-Code2flow is useful for:
-- Untangling spaghetti code.
+Pasta is useful for:
+- Untangling spaghetti code (The inspiration of the project's name).
 - Identifying orphaned functions.
+- Identifying arguments passed into functions.
+- Identifying variables assigned in functions.
+- Provide a better "bird's eye view" of your codebase to get a better     understanding of its architechure 
 - Getting new developers up to speed.
 
-Code2flow provides a *pretty good estimate* of your project's structure. No algorithm can generate a perfect call graph for a [dynamic language](https://en.wikipedia.org/wiki/Dynamic_programming_language) – even less so if that language is [duck-typed](https://en.wikipedia.org/wiki/Duck_typing). See the known limitations in the section below.
+Pasta provides a *pretty good estimate* of your project's structure but there may be some issues in identifying nodes, certian variables. These issues will be a further focus of improvement in Pasta.
 
 *(Below: Code2flow running against a subset of itself `code2flow code2flow/engine.py code2flow/python.py --target-function=code2flow --downstream-depth=3`)*
 

--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -260,9 +260,10 @@ class Call():
 
 
 class Node():
-    def __init__(self, token, calls, variables, parent, import_tokens=None,
+    def __init__(self, token, args, calls, variables, parent, import_tokens=None,
                  line_number=None, is_constructor=False):
         self.token = token
+        self.args = args
         self.line_number = line_number
         self.calls = calls
         self.variables = variables

--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -348,31 +348,30 @@ class Node():
         if self.line_number is not None:
 
             tbl = f"""
-                <<TABLE CELLSPACING='0' CELLPADDING='10' BORDER='1'>
+                <<TABLE CELLSPACING='0' CELLPADDING='4' BORDER='1'>
                     <TR>
-                        <TD COLSPAN='1' ALIGN='left' BORDER='0'>Ln: <B>{self.line_number}</B></TD>
-                        <TD ALIGN='right' BORDER='0'><B>{self.token}()</B></TD>
+                        <TD COLSPAN='1' ALIGN='LEFT' BORDER='0'>Ln: <B>{self.line_number}</B></TD>
+                        <TD ALIGN='RIGHT' BORDER='0'><B>{self.token}()</B></TD>
                     </TR>
                     <TR>
                 """
             tbl += """
-                        <TD></TD>
                         <TD>
-                            <TABLE CELLSPACING='0' BORDER='0' CELLPADDING='4'>
+                            <TABLE CELLSPACING='0' BORDER='0' CELLPADDING='2'>
                                 <TR>
                                     <TD ALIGN='TEXT' BORDER='1'><B>Arguments: </B></TD>
                                 </TR>
                                 <TR>
-                                    <TD>
-                """
+                                    <TD ALIGN='LEFT'>"""
             for arg in self.args:
-                tbl += f"""{arg}/n"""
+                tbl += f"""{arg}<BR ALIGN='LEFT'/>"""
 
             tbl += """
                                     </TD>
                                 </TR>
                             </TABLE>
                         </TD>
+                        <TD></TD>
                     </TR>
                 </TABLE>>
                 """

--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -346,7 +346,37 @@ class Node():
         :rtype: str
         """
         if self.line_number is not None:
-            return f"{self.line_number}: {self.token}()"
+
+            tbl = f"""
+                <<TABLE CELLSPACING='0' CELLPADDING='10' BORDER='1'>
+                    <TR>
+                        <TD COLSPAN='1' ALIGN='left' BORDER='0'>Ln: <B>{self.line_number}</B></TD>
+                        <TD ALIGN='right' BORDER='0'><B>{self.token}()</B></TD>
+                    </TR>
+                    <TR>
+                """
+            tbl += """
+                        <TD></TD>
+                        <TD>
+                            <TABLE CELLSPACING='0' BORDER='0' CELLPADDING='4'>
+                                <TR>
+                                    <TD ALIGN='TEXT' BORDER='1'><B>Arguments: </B></TD>
+                                </TR>
+                                <TR>
+                                    <TD>
+                """
+            for arg in self.args:
+                tbl += f"""{arg}/n"""
+
+            tbl += """
+                                    </TD>
+                                </TR>
+                            </TABLE>
+                        </TD>
+                    </TR>
+                </TABLE>>
+                """
+            return tbl.strip('"')
         return f"{self.token}()"
 
     def remove_from_parent(self):
@@ -410,8 +440,9 @@ class Node():
         attributes = {
             'label': self.label(),
             'name': self.name(),
-            'shape': "rect",
+            'shape': "plaintext",
             'style': 'rounded,filled',
+            'fontname': 'Arial',
             'fillcolor': NODE_COLOR,
         }
         if self.is_trunk:
@@ -421,7 +452,10 @@ class Node():
 
         ret = self.uid + ' ['
         for k, v in attributes.items():
-            ret += f'{k}="{v}" '
+            if k == 'label':
+                ret += f'{k}={v} '
+            else:
+                ret += f'{k}="{v}" '
         ret += ']'
         return ret
 

--- a/code2flow/python.py
+++ b/code2flow/python.py
@@ -114,7 +114,7 @@ def make_arguments(arguments):
             print('arg: ', arg.arg, ' has annotation: ', arg.annotation.id)
         
         arg_name_list.append(arg.arg)
-        
+
     return arg_name_list
             
         
@@ -215,10 +215,12 @@ class Python(BaseLanguage):
         :rtype: list[Node]
         """
         token = tree.name
+        arguments = make_arguments(tree.args)
         line_number = tree.lineno
         calls = make_calls(tree.body)
         variables = make_local_variables(tree.body, parent)
         is_constructor = False
+
         if parent.group_type == GROUP_TYPE.CLASS and token in ['__init__', '__new__']:
             is_constructor = True
 
@@ -226,7 +228,7 @@ class Python(BaseLanguage):
         if parent.group_type == GROUP_TYPE.FILE:
             import_tokens = [djoin(parent.token, token)]
 
-        return [Node(token, calls, variables, parent, import_tokens=import_tokens,
+        return [Node(token, arguments, calls, variables, parent, import_tokens=import_tokens,
                      line_number=line_number, is_constructor=is_constructor)]
 
     @staticmethod

--- a/code2flow/python.py
+++ b/code2flow/python.py
@@ -103,7 +103,21 @@ def process_import(element):
         ret.append(Variable(token, points_to=rhs, line_number=element.lineno))
     return ret
 
+def make_arguments(arguments):
 
+    args_obj_list = arguments.args
+    arg_name_list = []
+
+    for arg in args_obj_list:
+        
+        if arg.annotation != None:
+            print('arg: ', arg.arg, ' has annotation: ', arg.annotation.id)
+        
+        arg_name_list.append(arg.arg)
+        
+    return arg_name_list
+            
+        
 def make_local_variables(lines, parent):
     """
     Given an ast of all the lines in a function, generate a list of

--- a/code2flow/python.py
+++ b/code2flow/python.py
@@ -245,7 +245,7 @@ class Python(BaseLanguage):
         line_number = 0
         calls = make_calls(lines)
         variables = make_local_variables(lines, parent)
-        return Node(token, calls, variables, line_number=line_number, parent=parent)
+        return Node(token, [], calls, variables, line_number=line_number, parent=parent)
 
     @staticmethod
     def make_class_group(tree, parent):


### PR DESCRIPTION
This PR adds Arguments from each function and displays them in each node in the output diagram.
- Extended the Node class to include arguments
- Created a new function to get argument names from the Python AST module
- Reformatted the label to include the arguments as a list under the function name and line number