### PR TITLE
New --color-scheme argument

### DIFF
--- a/code2flow/engine.py
+++ b/code2flow/engine.py
@@ -841,7 +841,7 @@ def main(sys_argv=None):
         help='add more logging')
     parser.add_argument(
         '--version', action='version', version='%(prog)s ' + VERSION)
-    parser.add_argument('--color-scheme', action='store', choices=list(COLOR_SCHEMES.keys()),
+    parser.add_argument('--color-scheme', action='store', choices=list(COLOR_SCHEMES.keys()), default='default',
                         help="select a color for the graph legend")
 
     sys_argv = sys_argv or sys.argv[1:]

--- a/code2flow/model.py
+++ b/code2flow/model.py
@@ -2,11 +2,18 @@ import abc
 import os
 
 
-TRUNK_COLOR = '#966F33'
-LEAF_COLOR = '#6db33f'
 EDGE_COLORS = ["#000000", "#E69F00", "#56B4E9", "#009E73",
                "#F0E442", "#0072B2", "#D55E00", "#CC79A7"]
-NODE_COLOR = "#cccccc"
+
+#  (NODE_COLOR, TRUNK_COLOR, LEAF_COLOR)
+COLOR_SCHEMES = {
+    'default': ('#cccccc', '#966F33', '#6db33f'),
+    'blue': ('#138bfa', '#989a97', '#044a9a'),
+    'desert': ('#fda653', '#ffecd5', '#d57720'),
+    'pink': ('#b99cd6', '#ddd5d7', '#cb3870'),
+    'light_blue': ('#ace2ff', '#feffff', '#5bcce0'),
+    'aqua': ('#1a9e85', '#304960', '#1fdec3'),
+}
 
 
 class Namespace(dict):
@@ -401,7 +408,7 @@ class Node():
             else:
                 assert isinstance(variable.points_to, (Node, Group))
 
-    def to_dot(self):
+    def to_dot(self, color_scheme='default'):
         """
         Output for graphviz (.dot) files
         :rtype: str
@@ -411,12 +418,12 @@ class Node():
             'name': self.name(),
             'shape': "rect",
             'style': 'rounded,filled',
-            'fillcolor': NODE_COLOR,
+            'fillcolor': COLOR_SCHEMES[color_scheme][0],
         }
         if self.is_trunk:
-            attributes['fillcolor'] = TRUNK_COLOR
+            attributes['fillcolor'] = COLOR_SCHEMES[color_scheme][1]
         elif self.is_leaf:
-            attributes['fillcolor'] = LEAF_COLOR
+            attributes['fillcolor'] = COLOR_SCHEMES[color_scheme][2]
 
         ret = self.uid + ' ['
         for k, v in attributes.items():


### PR DESCRIPTION
A new CLI argument '--color-scheme' to allow the user to change the color scheme of the generated graph.  The list of schemes can be found at the top of model.py.

If no argument is provided, then the default color scheme will be used, which is the scheme used before this request.

Addresses issue: https://github.com/scottrogowski/code2flow/issues/76#issue-1609843824